### PR TITLE
Add support for using a ChartView inside an iOS Storyboard

### DIFF
--- a/Sources/Microcharts.iOS/ChartView.cs
+++ b/Sources/Microcharts.iOS/ChartView.cs
@@ -1,4 +1,6 @@
-﻿using SkiaSharp;
+﻿using System;
+using Foundation;
+using SkiaSharp;
 #if __IOS__
 namespace Microcharts.iOS
 {
@@ -11,11 +13,28 @@ namespace Microcharts.macOS
     using SkiaSharp.Views.Mac;
 #endif
 
+    [Register("ChartView")]
     public class ChartView : SKCanvasView
     {
         #region Constructors
 
         public ChartView()
+        {
+            Initialize();
+        }
+
+        [Preserve]
+        public ChartView(IntPtr handle) : base(handle)
+        {
+        }
+
+        public override void AwakeFromNib()
+        {
+            base.AwakeFromNib();
+            Initialize();
+        }
+
+        private void Initialize()
         {
 #if __IOS__
             this.BackgroundColor = UIColor.Clear;


### PR DESCRIPTION
I added Storyboard support to ChartView.

The needed changes are:
- register the class with iOS so the native iOS reflection method can find it
- move initialization code in AwakeFromNib as storyboard instantiation is a 2 step process (step2)
- add an empty constructor with a handle parameter as storyboard instantiation is a 2 step process (step1)
