### PR TITLE
Fixed swapped parameters in property registration

### DIFF
--- a/Sources/Microcharts.Uwp/ChartView.cs
+++ b/Sources/Microcharts.Uwp/ChartView.cs
@@ -10,7 +10,7 @@
             this.PaintSurface += OnPaintCanvas;
         }
 
-        public static readonly DependencyProperty ChartProperty = DependencyProperty.Register(nameof(Chart), typeof(ChartView), typeof(Chart), new PropertyMetadata(null, new PropertyChangedCallback(OnLabelChanged)));
+        public static readonly DependencyProperty ChartProperty = DependencyProperty.Register(nameof(Chart), typeof(Chart), typeof(ChartView), new PropertyMetadata(null, new PropertyChangedCallback(OnLabelChanged)));
 
         public Chart Chart
         {


### PR DESCRIPTION
UWP Chart binding was crashing (Failed to assign to property) due to swapped propertyType and ownerType parameters.