### PR TITLE
MinBarHeight drawing & YAxis measure fix

### DIFF
--- a/Sources/Microcharts.Samples/Data.cs
+++ b/Sources/Microcharts.Samples/Data.cs
@@ -121,41 +121,7 @@ namespace Microcharts.Samples
         public static Chart[] CreateXamarinSample()
         {
             ChartEntry[] entries = GenerateDefaultXamarinEntries();
-
-            var entriesLabeledColor = new[]
-            {
-                new ChartEntry(212)
-                {
-                    Label = "UWP",
-                    ValueLabel = "112",
-                    Color = SKColor.Parse("#2c3e50"),
-                    ValueLabelColor = SKColor.Parse("#2c3e50"),
-                },
-                new ChartEntry(248)
-                {
-                    Label = "Android",
-                    ValueLabel = "648",
-                    Color = SKColor.Parse("#77d065"),
-                    ValueLabelColor = SKColor.Parse("#77d065"),
-                },
-                new ChartEntry(128)
-                {
-                    Label = "iOS",
-                    ValueLabel = "428",
-                    Color = SKColor.Parse("#b455b6"),
-                    ValueLabelColor = SKColor.Parse("#b455b6"),
-                },
-                new ChartEntry(514)
-                {
-                    Label = "Forms",
-                    ValueLabel = "214",
-                    Color = SKColor.Parse("#3498db"),
-                    ValueLabelColor = SKColor.Parse("#3498db"),
-                }
-            };
-
             Random r = new Random(18);
-
             return new Chart[]
             {
                 new BarChart

--- a/Sources/Microcharts/Charts/BarChart.cs
+++ b/Sources/Microcharts/Charts/BarChart.cs
@@ -52,7 +52,7 @@ namespace Microcharts
             {
                 var x = barX - (itemSize.Width / 2);
                 var y = Math.Min(origin, barY);
-                var height = Math.Max(MinBarHeight, Math.Abs(origin - barY));
+                var height = Math.Abs(origin - barY);
                 if (height < MinBarHeight)
                 {
                     height = MinBarHeight;

--- a/Sources/Microcharts/Helpers/MeasureHelper.cs
+++ b/Sources/Microcharts/Helpers/MeasureHelper.cs
@@ -77,8 +77,17 @@ namespace Microcharts
                 var yAxisWidth = width;
 
                 var enumerable = entries.ToList(); // to avoid double enumeration
+                var minValue = enumerable.Min(e => e.Value);
+                var maxValue = enumerable.Max(e => e.Value);
+                if(minValue == maxValue)
+                {
+                    if (minValue >= 0)
+                        maxValue += 100;
+                    else
+                        maxValue = 0;
+                }
 
-                NiceScale.Calculate(enumerable.Min(e => e.Value), enumerable.Max(e => e.Value), yAxisMaxTicks, out var range, out var tickSpacing, out var niceMin, out var niceMax);
+                NiceScale.Calculate(minValue, maxValue, yAxisMaxTicks, out var range, out var tickSpacing, out var niceMin, out var niceMax);
 
                 var ticks = (int)(range / tickSpacing);
 


### PR DESCRIPTION
- Fix YAxis measures crash when no data in chart : 
Library crash when no data (or only data with the same value) is in the chart during the Y axis measure.

- Fix MinBarHeight drawing : 
Drawing of Bar with value at 0 does not make accordingly to the MinBarHeight property