### PR TITLE
Update Pipelines to support Android 29 and JDK 11

### DIFF
--- a/.github/workflows/CI-Windows.yml
+++ b/.github/workflows/CI-Windows.yml
@@ -6,8 +6,6 @@ on:
 
 jobs:
   Windows-nuget-Builds:
-    env:
-      DOTNET_NOLOGO: true
 
     runs-on: windows-latest
     steps:
@@ -46,11 +44,12 @@ jobs:
 
     - name: "Build and pack Microcharts"
       run: msbuild /t:build,pack /p:Configuration=Release Sources/Microcharts/Microcharts.csproj
+    
     - name: "Install Android SDK"
       uses: mndvs/android-sdk-setup@v1
-        with: 
-          api-level: 29
-          build-tools-version: 32.0.0
+      with: 
+        api-level: 29
+        build-tools-version: 32.0.0
           
     - name: "Build and pack Microcharts Android"
       run: msbuild /t:build,pack /p:Configuration=Release Sources/Microcharts.Droid/Microcharts.Droid.csproj

--- a/.github/workflows/CI-Windows.yml
+++ b/.github/workflows/CI-Windows.yml
@@ -46,7 +46,7 @@ jobs:
       run: msbuild /t:build,pack /p:Configuration=Release Sources/Microcharts/Microcharts.csproj
     
     - name: "Install Android SDK"
-      uses: mndvs/android-sdk-setup@v1
+      uses: android-actions/setup-android@v2
       with: 
         api-level: 29
         build-tools-version: 32.0.0

--- a/.github/workflows/CI-Windows.yml
+++ b/.github/workflows/CI-Windows.yml
@@ -51,6 +51,12 @@ jobs:
     - name: Install Android SDK packages
       run: |
         sdkmanager "platforms;android-29" "build-tools;29.0.2"
+
+    - name: Set up JDK 11
+      uses: actions/setup-java@v2
+      with:
+          java-version: '11'
+          distribution: 'adopt'
           
     - name: "Build and pack Microcharts Android"
       run: msbuild /t:build,pack /p:Configuration=Release Sources/Microcharts.Droid/Microcharts.Droid.csproj

--- a/.github/workflows/CI-Windows.yml
+++ b/.github/workflows/CI-Windows.yml
@@ -6,6 +6,9 @@ on:
 
 jobs:
   Windows-nuget-Builds:
+    env:
+      NUGET_AUTH_TOKEN: ${{secrets.NUGET_API_TOKEN}}
+      DOTNET_NOLOGO: true
 
     runs-on: windows-latest
     steps:
@@ -44,20 +47,7 @@ jobs:
 
     - name: "Build and pack Microcharts"
       run: msbuild /t:build,pack /p:Configuration=Release Sources/Microcharts/Microcharts.csproj
-    
-    - name: Set up Android SDK
-      uses: android-actions/setup-android@v2
 
-    - name: Install Android SDK packages
-      run: |
-        sdkmanager "platforms;android-29" "build-tools;29.0.2"
-
-    - name: Set up JDK 11
-      uses: actions/setup-java@v2
-      with:
-          java-version: '11'
-          distribution: 'adopt'
-          
     - name: "Build and pack Microcharts Android"
       run: msbuild /t:build,pack /p:Configuration=Release Sources/Microcharts.Droid/Microcharts.Droid.csproj
 
@@ -90,3 +80,9 @@ jobs:
 
     - name: "Build and pack Microcharts Meta-package"
       run: dotnet pack Sources/Microcharts.Metapackage/Microcharts.Metapackage.csproj
+
+    - name: Publish packages to nuget.org
+      run: |
+        cd artifacts
+        dir *.nupkg
+        nuget push "*.nupkg" -SkipDuplicate -NoSymbols -ApiKey $NUGET_AUTH_TOKEN -Source https://api.nuget.org/v3/index.json

--- a/.github/workflows/CI-Windows.yml
+++ b/.github/workflows/CI-Windows.yml
@@ -7,7 +7,6 @@ on:
 jobs:
   Windows-nuget-Builds:
     env:
-      NUGET_AUTH_TOKEN: ${{secrets.NUGET_API_TOKEN}}
       DOTNET_NOLOGO: true
 
     runs-on: windows-latest
@@ -47,7 +46,12 @@ jobs:
 
     - name: "Build and pack Microcharts"
       run: msbuild /t:build,pack /p:Configuration=Release Sources/Microcharts/Microcharts.csproj
-
+    - name: "Install Android SDK"
+      uses: mndvs/android-sdk-setup@v1
+        with: 
+          api-level: 29
+          build-tools-version: 32.0.0
+          
     - name: "Build and pack Microcharts Android"
       run: msbuild /t:build,pack /p:Configuration=Release Sources/Microcharts.Droid/Microcharts.Droid.csproj
 
@@ -80,9 +84,3 @@ jobs:
 
     - name: "Build and pack Microcharts Meta-package"
       run: dotnet pack Sources/Microcharts.Metapackage/Microcharts.Metapackage.csproj
-
-    - name: Publish packages to nuget.org
-      run: |
-        cd artifacts
-        dir *.nupkg
-        nuget push "*.nupkg" -SkipDuplicate -NoSymbols -ApiKey $NUGET_AUTH_TOKEN -Source https://api.nuget.org/v3/index.json

--- a/.github/workflows/CI-Windows.yml
+++ b/.github/workflows/CI-Windows.yml
@@ -48,6 +48,19 @@ jobs:
     - name: "Build and pack Microcharts"
       run: msbuild /t:build,pack /p:Configuration=Release Sources/Microcharts/Microcharts.csproj
 
+    - name: Set up Android SDK
+      uses: android-actions/setup-android@v2
+    
+    - name: Install Android SDK packages
+      run: |
+        sdkmanager "platforms;android-29" "build-tools;29.0.2"
+        
+    - name: Set up JDK 11
+      uses: actions/setup-java@v2
+      with:
+          java-version: '11'
+          distribution: 'adopt'
+
     - name: "Build and pack Microcharts Android"
       run: msbuild /t:build,pack /p:Configuration=Release Sources/Microcharts.Droid/Microcharts.Droid.csproj
 

--- a/.github/workflows/CI-Windows.yml
+++ b/.github/workflows/CI-Windows.yml
@@ -45,11 +45,12 @@ jobs:
     - name: "Build and pack Microcharts"
       run: msbuild /t:build,pack /p:Configuration=Release Sources/Microcharts/Microcharts.csproj
     
-    - name: "Install Android SDK"
+    - name: Set up Android SDK
       uses: android-actions/setup-android@v2
-      with: 
-        api-level: 29
-        build-tools-version: 32.0.0
+
+    - name: Install Android SDK packages
+      run: |
+        sdkmanager "platforms;android-29" "build-tools;29.0.2"
           
     - name: "Build and pack Microcharts Android"
       run: msbuild /t:build,pack /p:Configuration=Release Sources/Microcharts.Droid/Microcharts.Droid.csproj


### PR DESCRIPTION
@eman1986 - This PR is Implementing changes to the pipeline to reflect required changes for issue 359

This will allow the nuget deploy pipeline to work once again.

This does the following
- Sets up Android
- Installs Android 29
- Sets up JDK 11

[#359](https://github.com/microcharts-dotnet/Microcharts/issues/359)