### PR TITLE
Fix UIKitThreadAccessException during chart animation on iOS

### DIFF
--- a/Sources/Microcharts.Maui/ChartView.cs
+++ b/Sources/Microcharts.Maui/ChartView.cs
@@ -59,7 +59,7 @@ namespace Microcharts.Maui
 
             if (view.chart != null)
             {
-                view.handler = view.chart.ObserveInvalidate(view, (v) => v.InvalidateSurface());
+                view.handler = view.chart.ObserveInvalidate(view, (v) => v.Dispatcher.Dispatch(v.InvalidateSurface));
             }
         }
 


### PR DESCRIPTION
## Summary

- Marshal `InvalidateSurface()` through `Dispatcher.Dispatch()` in the MAUI `ChartView` invalidation callback to avoid calling UIKit from a background thread

The `DelayTimer` used by `Chart.AnimateAsync` fires its step callback on a background thread. This updates `AnimationProgress`, which triggers `InvalidateSurface()` -> `UIView.SetNeedsDisplay()`. On iOS, UIKit throws a `UIKitThreadAccessException` because `SetNeedsDisplay` must be called from the main thread.

Fixes follesoe/Microcharts#1

🤖 Generated with [Claude Code](https://claude.com/claude-code)