### PR TITLE
Fix CI build failures from toolchain drift

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -37,7 +37,7 @@ jobs:
         if: matrix.os == 'macos-26'
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '26.3'
+          xcode-version: latest-stable
 
       - name: "Build solution"
         run: dotnet build Sources/Microcharts.Maui.sln --configuration Release

--- a/Sources/Microcharts.Droid/Microcharts.Droid.csproj
+++ b/Sources/Microcharts.Droid/Microcharts.Droid.csproj
@@ -11,11 +11,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="SkiaSharp.Views" Version="3.116.1" />
-    <PackageReference Include="NuGet.Build.Tasks.Pack">
-      <Version>6.5.0</Version>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../Microcharts/Microcharts.csproj" />

--- a/Sources/Microcharts.iOS/Microcharts.iOS.csproj
+++ b/Sources/Microcharts.iOS/Microcharts.iOS.csproj
@@ -11,11 +11,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="SkiaSharp.Views" Version="3.116.1" />
-    <PackageReference Include="NuGet.Build.Tasks.Pack">
-      <Version>6.5.0</Version>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../Microcharts/Microcharts.csproj" />


### PR DESCRIPTION
## Summary

The first CI run in ~2 months surfaced two unrelated, pre-existing build failures caused by toolchain drift (not by any source change). This fixes both.

### Windows — `NU1012` on pack
Packing `Microcharts.Droid` failed with `Some dependency group TFMs are missing a platform version: net10.0-android` (and `Microcharts.iOS` would have hit the same). Both projects pinned an obsolete **`NuGet.Build.Tasks.Pack 6.5.0`** that mishandles modern platform-version TFMs. `Microcharts.Core` and `Microcharts.Maui` use the SDK's built-in packer and pack fine — so the pin is removed from Droid and iOS.

Verified locally: `dotnet pack` on both projects now succeeds with no `NU1012`.

### macOS — Xcode/SDK mismatch
The build failed with `This version of .NET for iOS (26.5.x) requires Xcode 26.5. The current version of Xcode is 26.3.` The `Select Xcode` step pinned `26.3` while the floating iOS/MacCatalyst workloads now require `26.5`. Switched to **`latest-stable`** so Xcode tracks the installed workload and this drift cannot recur.

Merging this unblocks the failing required check on #374 and #375.

🤖 Generated with [Claude Code](https://claude.com/claude-code)