### PR TITLE
Fix DonutChart infinite loop with null-valued entries in LeftAndRight label mode

### DIFF
--- a/Sources/Microcharts/Charts/DonutChart.cs
+++ b/Sources/Microcharts/Charts/DonutChart.cs
@@ -118,20 +118,20 @@ namespace Microcharts
             while (i < Entries.Count() && (current < sumValue / 2))
             {
                 var entry = Entries.ElementAt(i);
+                i++;
                 if (!entry.Value.HasValue) continue;
 
                 rightValues.Add(entry);
                 current += Math.Abs(entry.Value.Value);
-                i++;
             }
 
             while (i < Entries.Count())
             {
                 var entry = Entries.ElementAt(i);
+                i++;
                 if (!entry.Value.HasValue) continue;
 
                 leftValues.Add(entry);
-                i++;
             }
 
             leftValues.Reverse();


### PR DESCRIPTION
## Summary

`DonutChart.DrawCaptionLeftAndRight` (the default `LeftAndRight` label mode) skipped null-valued entries with `continue` **without advancing the loop index**, so any `DonutChart` that contained a null-valued entry and used the default label mode would spin forever — an app hang. The fix advances the index before the skip in both the right-side and left-side split loops, so `i` always progresses.

## Verification

Reproduced and fixed with a headless SkiaSharp render (a donut with a null-valued entry, default `LeftAndRight` mode):
- **Before:** `chart.Draw(...)` never returned — killed by a 12s watchdog.
- **After:** renders and returns immediately.

_Context:_ the originally-reported issue #124 ("5 labels, last one dropped") turned out to be already fixed; this hang is a separate defect found while investigating it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)