### PR TITLE
Decouple RadialGaugeChart gauge size from LineSize (#138)

### DIFF
--- a/Sources/Microcharts/Charts/RadialGaugeChart.cs
+++ b/Sources/Microcharts/Charts/RadialGaugeChart.cs
@@ -88,7 +88,10 @@ namespace Microcharts
                 var cx = width / 2;
                 var cy = height / 2;
                 var lineWidth = (LineSize < 0) ? (radius / ((Entries.Count() + 1) * 2)) : LineSize;
-                var radiusSpace = lineWidth * 2;
+                // Space the rings by the available radius rather than the stroke width, so a custom
+                // LineSize changes only the line thickness, not the overall gauge size (issue #138).
+                // In the auto case (LineSize < 0) this equals lineWidth * 2, so behaviour is unchanged.
+                var radiusSpace = radius / (Entries.Count() + 1);
 
                 for (int i = 0; i < Entries.Count(); i++)
                 {


### PR DESCRIPTION
## Summary

`RadialGaugeChart` derived the ring spacing from the stroke width (`radiusSpace = lineWidth * 2`), so a custom `LineSize` also scaled the overall gauge radius — a thin line produced a tiny gauge, and a large gauge forced a thick line.

This derives the ring spacing from the **available radius** instead:

```csharp
var radiusSpace = radius / (Entries.Count() + 1);
```

In the auto-size case (`LineSize < 0`) this equals the old `lineWidth * 2` exactly, so that path is unchanged. When `LineSize` is set, stroke width and gauge size are now independent — you can have a thin line on a decently-sized gauge.

## Verification

Confirmed in the iOS simulator with a single-entry gauge at `LineSize = 15`:
- **Before:** a tiny ~30px ring, regardless of available space.
- **After:** the gauge fills a decent size while keeping the thin line; the multi-ring "Default" example renders identically to before (auto path untouched).

Closes #138.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
