### PR TITLE
Marshal iOS/Droid chart redraws to the UI thread; remove dead PlanifyInvalidate (#245)

### DIFF
--- a/Sources/Microcharts.Droid/ChartView.cs
+++ b/Sources/Microcharts.Droid/ChartView.cs
@@ -60,7 +60,8 @@ namespace Microcharts.Droid
 
                     if (this.chart != null)
                     {
-                        this.handler = this.chart.ObserveInvalidate(this, (view) => { try { view.Invalidate(); } catch (ObjectDisposedException) { } });
+                        // PostInvalidate is safe from any thread: chart properties may be changed off the UI thread.
+                        this.handler = this.chart.ObserveInvalidate(this, (view) => { try { view.PostInvalidate(); } catch (ObjectDisposedException) { } });
                     }
                 }
             }

--- a/Sources/Microcharts.Droid/ChartView.cs
+++ b/Sources/Microcharts.Droid/ChartView.cs
@@ -56,7 +56,8 @@ namespace Microcharts.Droid
                     }
 
                     this.chart = value;
-                    this.Invalidate();
+                    // Marshal the initial invalidate too, in case Chart is assigned off the UI thread.
+                    this.PostInvalidate();
 
                     if (this.chart != null)
                     {

--- a/Sources/Microcharts.iOS/ChartView.cs
+++ b/Sources/Microcharts.iOS/ChartView.cs
@@ -60,7 +60,8 @@ namespace Microcharts.iOS
                     }
 
                     this.chart = value;
-                    this.InvalidateChart();
+                    // Marshal the initial invalidate too, in case Chart is assigned off the UI thread.
+                    this.BeginInvokeOnMainThread(this.InvalidateChart);
 
                     if (this.chart != null)
                     {

--- a/Sources/Microcharts.iOS/ChartView.cs
+++ b/Sources/Microcharts.iOS/ChartView.cs
@@ -64,7 +64,8 @@ namespace Microcharts.iOS
 
                     if (this.chart != null)
                     {
-                        this.handler = this.chart.ObserveInvalidate(this, (view) => view.InvalidateChart());
+                        // Marshal to the main thread: chart properties may be changed off the UI thread.
+                        this.handler = this.chart.ObserveInvalidate(this, (view) => view.BeginInvokeOnMainThread(view.InvalidateChart));
                     }
                 }
             }

--- a/Sources/Microcharts/Charts/Chart.cs
+++ b/Sources/Microcharts/Charts/Chart.cs
@@ -39,8 +39,6 @@ namespace Microcharts
 
         private TimeSpan animationDuration = TimeSpan.FromSeconds(1.5f);
 
-        private Task invalidationPlanification;
-
         private CancellationTokenSource animationCancellation;
 
         #endregion
@@ -445,25 +443,6 @@ namespace Microcharts
         /// Invalidate the chart.
         /// </summary>
         protected void Invalidate() => Invalidated?.Invoke(this, EventArgs.Empty);
-
-        /// <summary>
-        /// Planifies the invalidation.
-        /// </summary>
-        protected async void PlanifyInvalidate()
-        {
-            if (invalidationPlanification != null)
-            {
-                await invalidationPlanification;
-            }
-            else
-            {
-                invalidationPlanification = Task.Delay(200);
-                await invalidationPlanification;
-                Invalidate();
-                invalidationPlanification = null;
-            }
-        }
-
 
         #region Weak event handlers
 


### PR DESCRIPTION
## Summary

Addresses the two problems behind #245 ("Chart presumes properties are always changed on the UI thread; exceptions lost in `async void PlanifyInvalidate`").

**1. `PlanifyInvalidate` was dead code.** The `async void PlanifyInvalidate` method the issue called out has no call sites anywhere in the repo. Removed it (and its now-unused `invalidationPlanification` field).

**2. The native iOS/Droid views didn't marshal redraws to the UI thread.** When a chart property is changed off the UI thread (e.g. from a background polling task), the native views invoked UIKit/Android draw APIs on that thread → the crash the issue describes. The MAUI view already dispatches via `Dispatcher.Dispatch`; this brings the native views in line:

- **iOS:** `view.BeginInvokeOnMainThread(view.InvalidateChart)`
- **Droid:** `view.PostInvalidate()` (safe from any thread) instead of `view.Invalidate()`

No Core/architecture change — the platform-agnostic Core stays UI-thread-agnostic and marshaling lives in the views, matching how the MAUI view already works.

## Verification

- `dotnet build Sources/Microcharts.slnx --configuration Release` → builds clean across Core / iOS / Droid / MAUI.
- The change mirrors the MAUI view's already-proven `Dispatcher.Dispatch` marshaling. It's a redraw-threading fix that the MAUI demo can't exercise (that path uses the already-correct MAUI view), so it's verified by compilation + parity with the MAUI approach.

Closes #245.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
