### PR TITLE
Fix zero-value bar stubs (#263) and Y-axis overshoot below zero (#304)

### DIFF
--- a/Sources/Microcharts/Charts/BarChart.cs
+++ b/Sources/Microcharts/Charts/BarChart.cs
@@ -107,9 +107,11 @@ namespace Microcharts
             if (height > 0 && height < MinBarHeight)
             {
                 height = MinBarHeight;
-                if (y + height > Margin + itemSize.Height)
+                // Keep the bar anchored to the axis origin: a positive bar grows up from origin
+                // (a negative bar's top is already at origin and grows down from it).
+                if (barY < origin)
                 {
-                    y = headerHeight + itemSize.Height - height;
+                    y = origin - height;
                 }
             }
 

--- a/Sources/Microcharts/Charts/BarChart.cs
+++ b/Sources/Microcharts/Charts/BarChart.cs
@@ -102,8 +102,9 @@ namespace Microcharts
         {
             var x = barX - (itemSize.Width / 2);
             var y = Math.Min(origin, barY);
-            var height = Math.Max(MinBarHeight, Math.Abs(origin - barY));
-            if (height < MinBarHeight)
+            var height = Math.Abs(origin - barY);
+            // Enforce a minimum height only for non-zero bars, so a zero-value bar stays empty (issue #263).
+            if (height > 0 && height < MinBarHeight)
             {
                 height = MinBarHeight;
                 if (y + height > Margin + itemSize.Height)

--- a/Sources/Microcharts/Helpers/MeasureHelper.cs
+++ b/Sources/Microcharts/Helpers/MeasureHelper.cs
@@ -87,7 +87,9 @@ namespace Microcharts
                     }
 
                     NiceScale.Calculate(minValue, maxValue, yAxisMaxTicks, out range, out tickSpacing, out niceMin, out niceMax);
-                    ticks = (int)(range / tickSpacing);
+                    // Count ticks across the actual [niceMin, niceMax] axis span, not the nice data range, so the
+                    // axis never overshoots below niceMin (issue #304) or drops the final tick.
+                    ticks = (int)((niceMax - niceMin) / tickSpacing) + 1;
                 }
                 else
                 {


### PR DESCRIPTION
## Summary

Two BarChart / axis rendering fixes.

### #263 — zero-value bars rendered a stub
`BarChart.GetBarDrawingProperties` used `Math.Max(MinBarHeight, Abs(origin - barY))`, so a zero-value bar (true height 0) was forced up to `MinBarHeight` (4px). The minimum is now enforced only for **non-zero** bars, so zero-value bars stay empty.

### #304 — Y-axis could show a tick below zero (and could drop the 0 tick)
`MeasureHelper.CalculateYAxis` counted ticks from the nice **data range** (`NiceScale`'s `range` output) rather than the actual `[niceMin, niceMax]` axis span, so the labels could overshoot below `niceMin`. For all-positive data this drew a gridline below zero for some max values, and dropped the `0` tick for others. Counting ticks over `niceMax - niceMin` makes the labels span exactly the axis every time:

| data (min=0) | before | after |
|---|---|---|
| max = 510 | `600, 400, 200, 0, `**`-200`** | `600, 400, 200, 0` |
| max = 950 | `1000, 800, 600, 400, 200` (no 0) | `1000, 800, 600, 400, 200, `**`0`** |

## Verification
- **#263** confirmed in the iOS simulator: the two zero bars now render empty (screenshots before/after).
- **#304** confirmed by computing the generated tick labels directly (table above).
- The iOS sample (which compiles Microcharts core) builds clean; the full cross-platform build runs in CI.

Closes #263.
Closes #304.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
