### PR TITLE
Clear the drawing area so transparent-background charts don't stack frames

### DIFF
--- a/Sources/Microcharts/Charts/Chart.cs
+++ b/Sources/Microcharts/Charts/Chart.cs
@@ -297,11 +297,14 @@ namespace Microcharts
         {
             DrawableChartArea = new SKRect(0, 0, width, height);
 
-            // Clear just the drawing area to avoid messing up rest of the canvas in case it's shared
+            // Clear just the drawing area to avoid messing up rest of the canvas in case it's shared.
+            // Use Src blend so a transparent BackgroundColor actually replaces (clears) the previous
+            // frame rather than blending over it, which otherwise leaves stale content behind.
             using (var paint = new SKPaint
             {
                 Style = SKPaintStyle.Fill,
-                Color = BackgroundColor
+                Color = BackgroundColor,
+                BlendMode = SKBlendMode.Src
             })
             {
                 canvas.DrawRect(DrawableChartArea, paint);


### PR DESCRIPTION
## Summary

A chart with `BackgroundColor = SKColors.Transparent` didn't clear its previous render, so when it redrew (new data, animation) the old frame stayed underneath and content accumulated until the surface was recreated — e.g. by resizing the window. That's #363.

`Chart.Draw` filled the background with `canvas.DrawRect(area, paint)` using the default `SrcOver` blend, so drawing a transparent rect over the old pixels is a no-op. This draws the background with **`SKBlendMode.Src`** instead, which *replaces* the pixels in the drawing area (clearing it even when the background is transparent), while still only touching the chart's own area — not the rest of a shared canvas. Opaque backgrounds are unaffected (`Src` == `SrcOver` for opaque colors).

## Verification

Headless render test — pre-fill a 200×200 bitmap red (simulating a previous frame), draw a transparent-background chart, count leftover red pixels:

| | red pixels remaining |
|---|---|
| **before** | `24549` (of 40000) — previous frame not cleared |
| **after** | `0` — drawing area fully cleared |

Full solution builds clean.

Closes #363.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
