### PR TITLE
Upgrade to SkiaSharp 4 for Microcharts 3.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,22 +40,22 @@ jobs:
         dotnet workload list
 
     - name: "Restore and build solution"
-      run: dotnet build Sources/Microcharts.slnx --configuration Release -p:VersionPrelease=.${{ github.run_number }}
+      run: dotnet build Sources/Microcharts.slnx --configuration Release -p:VersionPrelease=-preview.${{ github.run_number }}
 
     - name: "Pack Microcharts Core"
-      run: dotnet pack Sources/Microcharts/Microcharts.csproj --configuration Release --no-build -p:VersionPrelease=.${{ github.run_number }}
+      run: dotnet pack Sources/Microcharts/Microcharts.csproj --configuration Release --no-build -p:VersionPrelease=-preview.${{ github.run_number }}
 
     - name: "Pack Microcharts Droid"
-      run: dotnet pack Sources/Microcharts.Droid/Microcharts.Droid.csproj --configuration Release --no-build -p:VersionPrelease=.${{ github.run_number }}
+      run: dotnet pack Sources/Microcharts.Droid/Microcharts.Droid.csproj --configuration Release --no-build -p:VersionPrelease=-preview.${{ github.run_number }}
 
     - name: "Pack Microcharts iOS"
-      run: dotnet pack Sources/Microcharts.iOS/Microcharts.iOS.csproj --configuration Release --no-build -p:VersionPrelease=.${{ github.run_number }}
+      run: dotnet pack Sources/Microcharts.iOS/Microcharts.iOS.csproj --configuration Release --no-build -p:VersionPrelease=-preview.${{ github.run_number }}
 
     - name: "Pack Microcharts MAUI"
-      run: dotnet pack Sources/Microcharts.Maui/Microcharts.Maui.csproj --configuration Release --no-build -p:VersionPrelease=.${{ github.run_number }}
+      run: dotnet pack Sources/Microcharts.Maui/Microcharts.Maui.csproj --configuration Release --no-build -p:VersionPrelease=-preview.${{ github.run_number }}
 
     - name: "Pack Microcharts Meta-package"
-      run: dotnet pack Sources/Microcharts.Metapackage/Microcharts.Metapackage.csproj --configuration Release -p:VersionPrelease=.${{ github.run_number }}
+      run: dotnet pack Sources/Microcharts.Metapackage/Microcharts.Metapackage.csproj --configuration Release -p:VersionPrelease=-preview.${{ github.run_number }}
 
     # Always publish the build to GitHub Packages (prerelease/CI feed).
     - name: Publish packages to GitHub Packages

--- a/Sources/Directory.Build.props
+++ b/Sources/Directory.Build.props
@@ -6,8 +6,13 @@
 
     <PropertyGroup>
         <!-- Change these two values to control the version -->
-        <VersionMain>2.0.0</VersionMain>
-        <VersionPrelease></VersionPrelease>
+        <VersionMain>3.0.0</VersionMain>
+        <VersionPrelease>-preview</VersionPrelease>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <!-- Single source of truth for the SkiaSharp package family version -->
+        <SkiaSharpVersion>4.150.1</SkiaSharpVersion>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/Sources/Microcharts.Droid/Microcharts.Droid.csproj
+++ b/Sources/Microcharts.Droid/Microcharts.Droid.csproj
@@ -10,7 +10,7 @@
     <PackageTags>maui anroid chart skia</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="SkiaSharp.Views" Version="3.119.4" />
+    <PackageReference Include="SkiaSharp.Views" Version="$(SkiaSharpVersion)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../Microcharts/Microcharts.csproj" />

--- a/Sources/Microcharts.Maui/Microcharts.Maui.csproj
+++ b/Sources/Microcharts.Maui/Microcharts.Maui.csproj
@@ -12,7 +12,7 @@
     <PackageProjectUrl>https://github.com/microcharts-dotnet/Microcharts.git</PackageProjectUrl>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="SkiaSharp.Views.Maui.Controls" Version="3.119.4" />
+    <PackageReference Include="SkiaSharp.Views.Maui.Controls" Version="$(SkiaSharpVersion)" />
     <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
   </ItemGroup>
   <ItemGroup>

--- a/Sources/Microcharts.Metapackage/Microcharts.Metapackage.csproj
+++ b/Sources/Microcharts.Metapackage/Microcharts.Metapackage.csproj
@@ -4,7 +4,8 @@
     <NuspecFile>Microcharts.Metapackage.nuspec</NuspecFile>
     <!-- Feed $version$ in the nuspec (package version + Microcharts.* deps) from the
          computed PackageVersion so the meta-package tracks the platform packages,
-         both for CI builds (2.0.0.<run>) and clean releases (2.0.0). -->
-    <NuspecProperties>version=$(PackageVersion)</NuspecProperties>
+         both for CI builds (3.0.0-preview.<run>) and clean releases (3.0.0).
+         $skiasharpversion$ keeps the SkiaSharp deps in lockstep with the projects. -->
+    <NuspecProperties>version=$(PackageVersion);skiasharpversion=$(SkiaSharpVersion)</NuspecProperties>
   </PropertyGroup>
 </Project>

--- a/Sources/Microcharts.Metapackage/Microcharts.Metapackage.nuspec
+++ b/Sources/Microcharts.Metapackage/Microcharts.Metapackage.nuspec
@@ -17,34 +17,34 @@
     <dependencies>
       <group targetFramework="net10.0">
         <dependency id="Microcharts.Core" version="$version$" />
-        <dependency id="SkiaSharp" version="3.119.4" />
+        <dependency id="SkiaSharp" version="$skiasharpversion$" />
       </group>
       <group targetFramework="net10.0-android36.0">
         <dependency id="Microcharts.Core" version="$version$" />
         <dependency id="Microcharts.Maui" version="$version$" />
-        <dependency id="SkiaSharp" version="3.119.4" />
-        <dependency id="SkiaSharp.Views" version="3.119.4" />
-        <dependency id="SkiaSharp.Views.Maui.Controls" version="3.119.4" />
+        <dependency id="SkiaSharp" version="$skiasharpversion$" />
+        <dependency id="SkiaSharp.Views" version="$skiasharpversion$" />
+        <dependency id="SkiaSharp.Views.Maui.Controls" version="$skiasharpversion$" />
       </group>
       <group targetFramework="net10.0-ios19.0">
         <dependency id="Microcharts.Core" version="$version$" />
         <dependency id="Microcharts.Maui" version="$version$" />
-        <dependency id="SkiaSharp" version="3.119.4" />
-        <dependency id="SkiaSharp.Views" version="3.119.4" />
-        <dependency id="SkiaSharp.Views.Maui.Controls" version="3.119.4" />
+        <dependency id="SkiaSharp" version="$skiasharpversion$" />
+        <dependency id="SkiaSharp.Views" version="$skiasharpversion$" />
+        <dependency id="SkiaSharp.Views.Maui.Controls" version="$skiasharpversion$" />
       </group>
       <group targetFramework="net10.0-maccatalyst19.0">
         <dependency id="Microcharts.Core" version="$version$" />
         <dependency id="Microcharts.Maui" version="$version$" />
-        <dependency id="SkiaSharp" version="3.119.4" />
-        <dependency id="SkiaSharp.Views" version="3.119.4" />
-        <dependency id="SkiaSharp.Views.Maui.Controls" version="3.119.4" />
+        <dependency id="SkiaSharp" version="$skiasharpversion$" />
+        <dependency id="SkiaSharp.Views" version="$skiasharpversion$" />
+        <dependency id="SkiaSharp.Views.Maui.Controls" version="$skiasharpversion$" />
       </group>
       <group targetFramework="net10.0-windows10.0.19041.0">
         <dependency id="Microcharts.Core" version="$version$" />
         <dependency id="Microcharts.Maui" version="$version$" />
-        <dependency id="SkiaSharp" version="3.119.4" />
-        <dependency id="SkiaSharp.Views.Maui.Controls" version="3.119.4" />
+        <dependency id="SkiaSharp" version="$skiasharpversion$" />
+        <dependency id="SkiaSharp.Views.Maui.Controls" version="$skiasharpversion$" />
       </group>
     </dependencies>
   </metadata>

--- a/Sources/Microcharts.Samples.Android/Microcharts.Samples.Android.csproj
+++ b/Sources/Microcharts.Samples.Android/Microcharts.Samples.Android.csproj
@@ -13,7 +13,7 @@
     <TrimMode>full</TrimMode>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="SkiaSharp.Views" Version="3.119.4" />
+    <PackageReference Include="SkiaSharp.Views" Version="$(SkiaSharpVersion)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../Microcharts.Droid/Microcharts.Droid.csproj" />

--- a/Sources/Microcharts.Samples.Maui/Microcharts.Samples.Maui.csproj
+++ b/Sources/Microcharts.Samples.Maui/Microcharts.Samples.Maui.csproj
@@ -53,7 +53,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SkiaSharp.Views.Maui.Controls" Version="3.119.4" />
+    <PackageReference Include="SkiaSharp.Views.Maui.Controls" Version="$(SkiaSharpVersion)" />
     <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
   </ItemGroup>
 

--- a/Sources/Microcharts.Samples.iOS/Microcharts.Samples.iOS.csproj
+++ b/Sources/Microcharts.Samples.iOS/Microcharts.Samples.iOS.csproj
@@ -15,7 +15,7 @@
     <CodesignKey>iPhone Developer</CodesignKey>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="SkiaSharp.Views" Version="3.119.4" />
+    <PackageReference Include="SkiaSharp.Views" Version="$(SkiaSharpVersion)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../Microcharts.iOS/Microcharts.iOS.csproj" />

--- a/Sources/Microcharts.iOS/Microcharts.iOS.csproj
+++ b/Sources/Microcharts.iOS/Microcharts.iOS.csproj
@@ -10,7 +10,7 @@
     <PackageTags>maui ios chart skia</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="SkiaSharp.Views" Version="3.119.4" />
+    <PackageReference Include="SkiaSharp.Views" Version="$(SkiaSharpVersion)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../Microcharts/Microcharts.csproj" />

--- a/Sources/Microcharts/Charts/HalfRadialGaugeChart.cs
+++ b/Sources/Microcharts/Charts/HalfRadialGaugeChart.cs
@@ -56,10 +56,13 @@ namespace Microcharts
                 IsAntialias = true,
             })
             {
-                using (SKPath path = new SKPath())
+                using (var builder = new SKPathBuilder())
                 {
-                    path.AddArc(SKRect.Create(cx - radius * 2, cy - radius * 2, 4 * radius, 4 * radius), 180, 180);
-                    canvas.DrawPath(path, paint);
+                    builder.AddArc(SKRect.Create(cx - radius * 2, cy - radius * 2, 4 * radius, 4 * radius), 180, 180);
+                    using (var path = builder.Detach())
+                    {
+                        canvas.DrawPath(path, paint);
+                    }
                 }
             }
         }
@@ -75,11 +78,14 @@ namespace Microcharts
                 IsAntialias = true,
             })
             {
-                using (SKPath path = new SKPath())
+                using (var builder = new SKPathBuilder())
                 {
                     var sweepAngle =  AnimationProgress * 180 * (Math.Abs(value) - AbsoluteMinimum) / ValueRange;
-                    path.AddArc(SKRect.Create(cx - radius * 2, cy - radius * 2, 4 * radius, 4 * radius), 180, sweepAngle);
-                    canvas.DrawPath(path, paint);
+                    builder.AddArc(SKRect.Create(cx - radius * 2, cy - radius * 2, 4 * radius, 4 * radius), 180, sweepAngle);
+                    using (var path = builder.Detach())
+                    {
+                        canvas.DrawPath(path, paint);
+                    }
                 }
             }
         }

--- a/Sources/Microcharts/Charts/Legacy/LegacyPointChart.cs
+++ b/Sources/Microcharts/Charts/Legacy/LegacyPointChart.cs
@@ -330,31 +330,10 @@ namespace Microcharts
         }
 
         /// <summary>
-        /// Measures the value labels with the text size of the given paint.
-        /// </summary>
-        /// <returns>The value labels.</returns>
-        protected SKRect[] MeasureLabels(string[] labels, SKPaint paint)
-        {
-            if (paint == null)
-            {
-                return MeasureLabels(labels);
-            }
-
-            using var font = new SKFont(SKTypeface.Default, paint.TextSize);
-            return MeasureHelper.MeasureTexts(labels, font);
-        }
-
-        /// <summary>
         /// Measures the value label.
         /// </summary>
         /// <returns>The value label.</returns>
         protected SKRect MeasureLabel(string label) => MeasureLabels(new[] { label }).First();
-
-        /// <summary>
-        /// Measures the value label with the text size of the given paint.
-        /// </summary>
-        /// <returns>The value label.</returns>
-        protected SKRect MeasureLabel(string label, SKPaint paint) => MeasureLabels(new[] { label }, paint).First();
         #endregion
     }
 }

--- a/Sources/Microcharts/Charts/LineChart.cs
+++ b/Sources/Microcharts/Charts/LineChart.cs
@@ -296,6 +296,13 @@ namespace Microcharts
                             }
                         }
 
+                        // Every entry was null, so no point was ever added to the path and
+                        // lastPoint still holds the placeholder used for null points.
+                        if (isFirst)
+                        {
+                            return;
+                        }
+
                         path.LineTo(lastPoint.X, origin);
                         path.Close();
                         using (var areaPath = path.Detach())

--- a/Sources/Microcharts/Charts/LineChart.cs
+++ b/Sources/Microcharts/Charts/LineChart.cs
@@ -190,8 +190,7 @@ namespace Microcharts
                             using (var shader = CreateXGradient(points, s.Entries, s.Color))
                                 paint.Shader = shader;
 
-                        var path = new SKPath();
-                        //path.MoveTo(points.First());
+                        using var path = new SKPathBuilder();
 
                         var isFirst = true;
                         var entries = s.Entries;
@@ -229,7 +228,10 @@ namespace Microcharts
                             }
                         }
 
-                        canvas.DrawPath(path, paint);
+                        using (var linePath = path.Detach())
+                        {
+                            canvas.DrawPath(linePath, paint);
+                        }
                     }
                 }
             }
@@ -251,7 +253,7 @@ namespace Microcharts
                     {
                         paint.Shader = EnableYFadeOutGradient ? SKShader.CreateCompose(shaderY, shaderX, SKBlendMode.SrcOut) : shaderX;
 
-                        var path = new SKPath();
+                        using var path = new SKPathBuilder();
 
                         var isFirst = true;
                         var entries = serie.Entries;
@@ -296,7 +298,10 @@ namespace Microcharts
 
                         path.LineTo(lastPoint.X, origin);
                         path.Close();
-                        canvas.DrawPath(path, paint);
+                        using (var areaPath = path.Detach())
+                        {
+                            canvas.DrawPath(areaPath, paint);
+                        }
                     }
                 }
             }

--- a/Sources/Microcharts/Charts/RadarChart.cs
+++ b/Sources/Microcharts/Charts/RadarChart.cs
@@ -103,9 +103,11 @@ namespace Microcharts
 
                 DrawBorder(canvas, center, radius);
 
-                using (var clip = new SKPath())
+                using var clipBuilder = new SKPathBuilder();
+                clipBuilder.AddCircle(center.X, center.Y, radius, SKPathDirection.Clockwise);
+
+                using (var clip = clipBuilder.Detach())
                 {
-                    clip.AddCircle(center.X, center.Y, radius);
 
                     
                     for (int i = 0; i < total; i++)

--- a/Sources/Microcharts/Charts/RadialGaugeChart.cs
+++ b/Sources/Microcharts/Charts/RadialGaugeChart.cs
@@ -70,11 +70,14 @@ namespace Microcharts
                 IsAntialias = true,
             })
             {
-                using (SKPath path = new SKPath())
+                using (var builder = new SKPathBuilder())
                 {
                     var sweepAngle = AnimationProgress * 360 * (Math.Abs(value) - AbsoluteMinimum) / ValueRange;
-                    path.AddArc(SKRect.Create(cx - radius, cy - radius, 2 * radius, 2 * radius), StartAngle, sweepAngle);
-                    canvas.DrawPath(path, paint);
+                    builder.AddArc(SKRect.Create(cx - radius, cy - radius, 2 * radius, 2 * radius), StartAngle, sweepAngle);
+                    using (var path = builder.Detach())
+                    {
+                        canvas.DrawPath(path, paint);
+                    }
                 }
             }
         }

--- a/Sources/Microcharts/Helpers/RadialHelpers.cs
+++ b/Sources/Microcharts/Helpers/RadialHelpers.cs
@@ -35,7 +35,7 @@ namespace Microcharts
 
             using var path = new SKPathBuilder();
 
-            // the the sector is a full circle, then do that
+            // if the sector is a full circle, then do that
             if (end - start == 1.0f)
             {
                 path.AddCircle(0, 0, outerRadius, SKPathDirection.Clockwise);
@@ -48,10 +48,6 @@ namespace Microcharts
             var startAngle = (TotalAngle * start) - UprightAngle;
             var endAngle = (TotalAngle * end) - UprightAngle;
             var large = endAngle - startAngle > PI ? SKPathArcSize.Large : SKPathArcSize.Small;
-            var sectorCenterAngle = ((endAngle - startAngle) / 2f) + startAngle;
-
-            // get the radius bits
-            var cectorCenterRadius = ((outerRadius - innerRadius) / 2f) + innerRadius;
 
             // calculate the angle for the margins
             var offsetR = outerRadius == 0 ? 0 : ((margin / (TotalAngle * outerRadius)) * TotalAngle);

--- a/Sources/Microcharts/Helpers/RadialHelpers.cs
+++ b/Sources/Microcharts/Helpers/RadialHelpers.cs
@@ -27,13 +27,13 @@ namespace Microcharts
 
         public static SKPath CreateSectorPath(float start, float end, float outerRadius, float innerRadius = 0.0f, float margin = 0.0f)
         {
-            var path = new SKPath();
-
             // if the sector has no size, then it has no path
             if (start == end)
             {
-                return path;
+                return new SKPath();
             }
+
+            using var path = new SKPathBuilder();
 
             // the the sector is a full circle, then do that
             if (end - start == 1.0f)
@@ -41,7 +41,7 @@ namespace Microcharts
                 path.AddCircle(0, 0, outerRadius, SKPathDirection.Clockwise);
                 path.AddCircle(0, 0, innerRadius, SKPathDirection.Clockwise);
                 path.FillType = SKPathFillType.EvenOdd;
-                return path;
+                return path.Detach();
             }
 
             // calculate the angles
@@ -80,7 +80,7 @@ namespace Microcharts
 
             path.Close();
 
-            return path;
+            return path.Detach();
         }
 
         #endregion

--- a/Sources/Microcharts/Microcharts.csproj
+++ b/Sources/Microcharts/Microcharts.csproj
@@ -13,6 +13,6 @@
     <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="SkiaSharp" Version="3.119.4" />
+    <PackageReference Include="SkiaSharp" Version="$(SkiaSharpVersion)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Opens the Microcharts 3.0 line: the whole solution now targets SkiaSharp 4.150.1, versioned as `3.0.0-preview`.

Because main was first migrated to the v4-compatible APIs that already exist in SkiaSharp 3 (0268ceb), the actual upgrade diff is small:

- **Remove the `SKPaint`-based `MeasureLabels`/`MeasureLabel` overloads** in `LegacyPointChart` — SkiaSharp 4 removes `SKPaint.TextSize`, so a paint can no longer carry text sizing. The `SKFont`-based overloads remain.
- **Bump every SkiaSharp reference to 4.150.1**, now centralized as a single `SkiaSharpVersion` property in `Sources/Directory.Build.props`, consumed by all csproj files and fed into the meta-package nuspec as `$skiasharpversion$`. Future bumps are a one-line change.
- **Migrate path construction to `SKPathBuilder`** (`LineChart`, `RadarChart`, both gauge charts, `RadialHelpers`) — SkiaSharp 4 obsoletes the `SKPath` mutation methods; `SKPathBuilder` mirrors them one for one, and `SKPathBuilder` does not exist in SkiaSharp 3, so this part is v3-only by necessity. Also fixes two line-chart paths that were never disposed.
- **`publish.yml` keeps the `-preview` marker** in the CI version suffix (`3.0.0-preview.<run>`); previously the run-number suffix replaced it, which would have made prerelease packages look stable on the feed.

The full solution (library, platform wrappers, samples) builds with zero errors and zero warnings, `dotnet pack` produces correctly-versioned `3.0.0-preview` packages with resolved nuspec dependencies, and the MAUI sample was verified visually on the iOS simulator (line charts with gradients and splines, Y-axis labels, value labels, legends all render identically to v2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)